### PR TITLE
Non trivial varargs with LLVM clang/clang++

### DIFF
--- a/interface/common.cpp
+++ b/interface/common.cpp
@@ -111,7 +111,7 @@ void openROM(QString filename)
     /* Try to load the ROM image into the core */
     if ((*CoreDoCommand)(M64CMD_ROM_OPEN, (int) romlength, ROM_buffer) != M64ERR_SUCCESS)
     {
-        DebugMessage(M64MSG_ERROR, "core failed to open ROM image file '%s'.", filename);
+        DebugMessage(M64MSG_ERROR, "core failed to open ROM image file '%s'.", filename.toUtf8().constData());
         free(ROM_buffer);
         (*CoreShutdown)();
         DetachCoreLib();

--- a/interface/common.cpp
+++ b/interface/common.cpp
@@ -77,7 +77,7 @@ void openROM(QString filename)
     FILE *fPtr = fopen(filename.toLatin1().data(), "rb");
     if (fPtr == NULL)
     {
-        DebugMessage(M64MSG_ERROR, "couldn't open ROM file '%s' for reading.", filename);
+        DebugMessage(M64MSG_ERROR, "couldn't open ROM file '%s' for reading.", filename.toUtf8().constData());
         (*CoreShutdown)();
         DetachCoreLib();
         return;
@@ -91,7 +91,7 @@ void openROM(QString filename)
     unsigned char *ROM_buffer = (unsigned char *) malloc(romlength);
     if (ROM_buffer == NULL)
     {
-        DebugMessage(M64MSG_ERROR, "couldn't allocate %li-byte buffer for ROM image file '%s'.", romlength, filename);
+        DebugMessage(M64MSG_ERROR, "couldn't allocate %li-byte buffer for ROM image file '%s'.", romlength, filename.toUtf8().constData());
         fclose(fPtr);
         (*CoreShutdown)();
         DetachCoreLib();
@@ -99,7 +99,7 @@ void openROM(QString filename)
     }
     else if (fread(ROM_buffer, 1, romlength, fPtr) != romlength)
     {
-        DebugMessage(M64MSG_ERROR, "couldn't read %li bytes from ROM image file '%s'.", romlength, filename);
+        DebugMessage(M64MSG_ERROR, "couldn't read %li bytes from ROM image file '%s'.", romlength, filename.toUtf8().constData());
         free(ROM_buffer);
         fclose(fPtr);
         (*CoreShutdown)();

--- a/interface/plugin.cpp
+++ b/interface/plugin.cpp
@@ -151,7 +151,7 @@ m64p_error PluginSearchLoad()
         {
             DebugMessage(M64MSG_INFO, "using %s plugin: '%s' v%i.%i.%i", g_PluginMap[i].name,
                    g_PluginMap[i].libname, VERSION_PRINTF_SPLIT(g_PluginMap[i].libversion));
-            DebugMessage(M64MSG_VERBOSE, "%s plugin library: %s", g_PluginMap[i].name, g_PluginMap[i].filename);
+            DebugMessage(M64MSG_VERBOSE, "%s plugin library: %s", g_PluginMap[i].name, g_PluginMap[i].filename.c_str());
         }
     }
 


### PR DESCRIPTION
The included changes allow for the code to compile and run on MacOS in my environment. I am on MacOS 10.12.3 Sierra, with XCode 8.2.1 (see `g++ --version` below), using Qt 5.6.2 as shipped with the Anaconda Python Distribution.

```
$ g++ --version
Configured with: --prefix=/Applications/Xcode.app/Contents/Developer/usr --with-gxx-include-dir=/usr/include/c++/4.2.1
Apple LLVM version 8.0.0 (clang-800.0.42.1)
Target: x86_64-apple-darwin16.4.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
```

When building, the following errors occurred:

```
../interface/plugin.cpp:154:103: error: cannot pass object of non-trivial type 'std::string' (aka 'basic_string<char,
      char_traits<char>, allocator<char> >') through variadic function; call will abort at runtime [-Wnon-pod-varargs]
            DebugMessage(M64MSG_VERBOSE, "%s plugin library: %s", g_PluginMap[i].name, g_PluginMap[i].filename);
                                                                                                      ^
1 error generated.
../interface/common.cpp:80:80: error: cannot pass object of non-trivial type 'QByteArray' through variadic function; call will abort at
      runtime [-Wnon-pod-varargs]
        DebugMessage(M64MSG_ERROR, "couldn't open ROM file '%s' for reading.", filename.toUtf8());
                                                                               ^
../interface/common.cpp:94:109: error: cannot pass object of non-trivial type 'QString' through variadic function; call will abort at
      runtime [-Wnon-pod-varargs]
        DebugMessage(M64MSG_ERROR, "couldn't allocate %li-byte buffer for ROM image file '%s'.", romlength, filename);
                                                                                                            ^
../interface/common.cpp:102:100: error: cannot pass object of non-trivial type 'QString' through variadic function; call will abort at
      runtime [-Wnon-pod-varargs]
        DebugMessage(M64MSG_ERROR, "couldn't read %li bytes from ROM image file '%s'.", romlength, filename);
                                                                                                   ^
../interface/common.cpp:114:80: error: cannot pass object of non-trivial type 'QString' through variadic function; call will abort at
      runtime [-Wnon-pod-varargs]
        DebugMessage(M64MSG_ERROR, "core failed to open ROM image file '%s'.", filename);
```

This appears to be due to the use of LLVM on MacOS, and is generated by `-Wnon-pod-varargs` as seen on http://fuckingclangwarnings.com .

If you don't have a Mac, you can reproduce this by using LLVM clang++ on, e.g., Ubuntu.

```
sudo apt-get install clang qt5-default
mkdir build
cd build
echo QMAKE_CC=clang >> ../mupen64plus-gui.pro
echo QMAKE_CXX=clang++ >> ../mupen64plus-gui.pro
qmake ../mupen64plus-gui.pro
make
```

So I guess the question here is "do you support LLVM clang?" Hopefully you're interested in saying "yes", because that leads to builds on MacOS.

Disclaimer: I don't know if the PR presented here is the best approach. I was mostly just trying to shut up the clang errors.