### PR TITLE
lambda from = to &, fix windows msvs build

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -40,7 +40,7 @@ MainWindow::MainWindow(QWidget *parent) :
         my_slots[i]->setText("Slot " + QString::number(i));
         my_slots[i]->setActionGroup(my_slots_group);
         SaveSlot->addAction(my_slots[i]);
-        connect(my_slots[i], &QAction::triggered,[=](bool checked){
+        connect(my_slots[i], &QAction::triggered,[&](bool checked){
             if (checked) {
                 int slot = my_slots[i]->text().remove("Slot ").toInt();
                 if (QtAttachCoreLib())
@@ -160,7 +160,7 @@ void MainWindow::updateOpenRecent()
         recent[i] = new QAction(this);
         recent[i]->setText(list.at(i));
         OpenRecent->addAction(recent[i]);
-        connect(recent[i], &QAction::triggered,[=](){
+        connect(recent[i], &QAction::triggered,[&](){
                     openROM(recent[i]->text());
                 });
     }


### PR DESCRIPTION
Building on Windows using MS Visual Studio Community 2015 and Qt 5.8.0 produces the following errors:

```
C:\Users\brent\code\mupen64plus-gui\mainwindow.cpp:45: error: C3478: 'my_slots' : an array cannot be captured by-value

C:\Users\brent\code\mupen64plus-gui\mainwindow.cpp:164: error: C3478: 'recent' : an array cannot be captured by-value
```

The lambda present at each statement should capture the arrays used by reference, so `[=]` (capture by value at definition time) is changed to `[&]` (capture by reference at execution time).