### PR TITLE
set top level menubar to native for mac/unity

### DIFF
--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -24,7 +24,7 @@
     </rect>
    </property>
    <property name="nativeMenuBar">
-    <bool>false</bool>
+    <bool>true</bool>
    </property>
    <widget class="QMenu" name="menuFile">
     <property name="title">


### PR DESCRIPTION
Just opened the ui file and ticked the nativeMenuBar checkbox for the menuBar. Then recompiled everywhere and tested on Mac, Windows, Linux with GNOME, and Linux with Ubuntu Unity.

I have screen shots but github is having asset issues at the moment and can't handle the uploads.