### PR TITLE
macos file selector typo

### DIFF
--- a/settingsdialog.cpp
+++ b/settingsdialog.cpp
@@ -13,7 +13,7 @@ void SettingsDialog::handleCoreButton()
 {
     QSettings settings("mupen64plus", "gui");
     QString fileName = QFileDialog::getOpenFileName(this,
-        tr("Locate Core Library"), NULL, tr("Shares Libraries (*.dynlib *.so* *.dll)"));
+        tr("Locate Core Library"), NULL, tr("Shares Libraries (*.dylib *.so* *.dll)"));
     if (!fileName.isNull()) {
         corePath->setText(fileName);
         settings.setValue("coreLibPath", fileName);


### PR DESCRIPTION
Allows the core library path to select a `.dylib` file, which is the extension on MacOS, rather than `.dynlib`.