### PR TITLE
Tell qmake to look for libraries in /usr/local

### DIFF
--- a/mupen64plus-gui.pro
+++ b/mupen64plus-gui.pro
@@ -41,7 +41,8 @@ LIBS += -Wl,-Bdynamic -lSDL2
 SOURCES += osal/osal_dynamiclib_unix.c \
     osal/osal_files_unix.c
 
-LIBS += -ldl -lSDL2
+LIBS += -L/usr/local/lib -ldl -lSDL2
+INCLUDEPATH += /usr/local/include
 }
 
 HEADERS  += mainwindow.h \


### PR DESCRIPTION
With Homebrew+macOS, SDL2 is installed under /usr/local, but qmake doesn't add that to include/library paths by default.