### PR TITLE
Save configuration (if desired) right before running game

### DIFF
--- a/interface/common.cpp
+++ b/interface/common.cpp
@@ -272,6 +272,11 @@ m64p_error openROM(std::string filename)
         DebugMessage(M64MSG_WARNING, "Couldn't set media loader, transferpak and GB carts will not work.");
     }
 
+    /* Save the configuration file again, just in case a plugin has altered it.
+       This is the last opportunity to save changes before the relatively
+       long-running game. */
+    (*ConfigSaveFile)();
+
     /* run the game */
     (*CoreDoCommand)(M64CMD_EXECUTE, 0, NULL);
 


### PR DESCRIPTION
This patch is parallel to commit 0bb63fe6f5a in mupen64plus-ui-console.
https://github.com/mupen64plus/mupen64plus-ui-console/commit/0bb63fe6f5a59fd18ad590c2a1df1f478cb93ea2

I intend to submit patches for removing configuration saving from
plugins (mupen64plus-audio-sdl is aleady done).

In exchange, the front-ends should save the configuration at the latest
safe opportunity, to capture any changes before most chances of crashes,
power outages, kill -9, etc.

Discussion:
https://github.com/mupen64plus/mupen64plus-audio-sdl/pull/26