### PR TITLE
Open Recent roms list enhancements

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -429,6 +429,12 @@ void MainWindow::updateOpenRecent()
     OpenRecent->clear();
     QAction *recent[RECENT_SIZE];
     QStringList list = settings->value("RecentROMs").toString().split(";");
+    if (list.first() == "") {
+        OpenRecent->setEnabled(false);
+        return;
+    }
+
+    OpenRecent->setEnabled(true);
     for (int i = 0; i < list.size() && i < RECENT_SIZE; ++i) {
         recent[i] = new QAction(this);
         recent[i]->setText(list.at(i));

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -444,6 +444,15 @@ void MainWindow::updateOpenRecent()
                     openROM(temp_recent->text());
                 });
     }
+    OpenRecent->addSeparator();
+
+    QAction *clearRecent = new QAction(this);
+    clearRecent->setText("Clear List");
+    OpenRecent->addAction(clearRecent);
+    connect(clearRecent, &QAction::triggered,[=](){
+        settings->remove("RecentROMs");
+        updateOpenRecent();
+    });
 }
 
 void MainWindow::setTitle(std::string title)


### PR DESCRIPTION
An empty 'Open Recent' list is now disabled and a 'Clear List' menu action has been added to let users clear their recently opened roms history.