### PR TITLE
add .rom file extension

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -792,7 +792,7 @@ void MainWindow::openROM(QString filename, QString netplay_ip, int netplay_port,
 void MainWindow::on_actionOpen_ROM_triggered()
 {
     QString filename = QFileDialog::getOpenFileName(this,
-        tr("Open ROM"), settings->value("ROMdir").toString(), tr("ROM Files (*.n64 *.N64 *.z64 *.Z64 *.v64 *.V64 *.zip *.ZIP *.7z)"));
+        tr("Open ROM"), settings->value("ROMdir").toString(), tr("ROM Files (*.n64 *.N64 *.z64 *.Z64 *.v64 *.V64 *.rom *.ROM *.zip *.ZIP *.7z)"));
     if (!filename.isNull()) {
         QFileInfo info(filename);
         settings->setValue("ROMdir", info.absoluteDir().absolutePath());

--- a/netplay/createroom.cpp
+++ b/netplay/createroom.cpp
@@ -133,7 +133,7 @@ void CreateRoom::onFinished(int)
 void CreateRoom::handleRomButton()
 {
     filename = QFileDialog::getOpenFileName(this,
-        tr("Open ROM"), w->getSettings()->value("ROMdir").toString(), tr("ROM Files (*.n64 *.N64 *.z64 *.Z64 *.v64 *.V64 *.zip *.ZIP *.7z)"));
+        tr("Open ROM"), w->getSettings()->value("ROMdir").toString(), tr("ROM Files (*.n64 *.N64 *.z64 *.Z64 *.v64 *.V64 *.rom *.ROM *.zip *.ZIP *.7z)"));
     if (!filename.isNull())
     {
         romButton->setText(filename);

--- a/netplay/joinroom.cpp
+++ b/netplay/joinroom.cpp
@@ -173,7 +173,7 @@ void JoinRoom::joinGame()
     }
 
     filename = QFileDialog::getOpenFileName(this,
-    tr("Open ROM"), w->getSettings()->value("ROMdir").toString(), tr("ROM Files (*.n64 *.N64 *.z64 *.Z64 *.v64 *.V64 *.zip *.ZIP *.7z)"));
+    tr("Open ROM"), w->getSettings()->value("ROMdir").toString(), tr("ROM Files (*.n64 *.N64 *.z64 *.Z64 *.v64 *.V64 *.rom *.ROM *.zip *.ZIP *.7z)"));
     if (!filename.isNull())
     {
         if (loadROM(filename) == M64ERR_SUCCESS)


### PR DESCRIPTION
i have seen some n64 prototypes use this file extension, you can easily just change the file extension from .rom to .z64 and it will run fine, however it does sometimes getting annoying so having the file extension just built into the emulator is nicer